### PR TITLE
fix(docker): use entrypoint, expose port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,5 @@ FROM alpine:3.18
 
 COPY --from=builder /op-plasma-celestia/bin/da-server /usr/local/bin/da-server
 
-CMD ["da-server"]
+EXPOSE 3100
+ENTRYPOINT ["/usr/local/bin/da-server"]


### PR DESCRIPTION
## Overview

This allows the docker image to accept flags at runtime. Also expose default port while here.

Fixes #14 