### PR TITLE
fix(server): return 500 in case of failure

### DIFF
--- a/celestia_server.go
+++ b/celestia_server.go
@@ -128,6 +128,11 @@ func (d *CelestiaServer) HandleGet(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	} else {
+		if input == nil {
+			responseSent = true
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 		responseSent = true
 		if _, err := w.Write(input); err != nil {
 			w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
## Overview

This PR fixes an edge case where the da server may return a 200 with empty response, which should be considered as an error.