### PR TITLE
fix(server): add start index, length

### DIFF
--- a/celestia_storage.go
+++ b/celestia_storage.go
@@ -148,7 +148,7 @@ func (d *CelestiaStore) Get(ctx context.Context, key []byte) ([]byte, error) {
 	}
 
 	blob, err := d.Client.Blob.Get(ctx, blobID.Height, d.Namespace, blobID.Commitment)
-	if err != nil || blob == nil {
+	if err != nil {
 		return nil, fmt.Errorf("celestia: failed to resolve frame: %w", err)
 	}
 	if blob == nil {

--- a/celestia_storage.go
+++ b/celestia_storage.go
@@ -26,21 +26,21 @@ type CelestiaBlobID struct {
 }
 
 // MarshalBinary serializes the CelestiaBlobID struct into a byte slice.
-func (id *CelestiaBlobID) MarshalBinary() ([]byte, error) {
+func (c *CelestiaBlobID) MarshalBinary() ([]byte, error) {
 	// Calculate the total length of the marshaled ID
 	// 8 bytes for Height + 32 bytes for Commitment + 4 bytes for ShareOffset + 4 bytes for ShareSize
-	marshaledID := make([]byte, 8+32+4+4)
+	id := make([]byte, 8+32+4+4)
 
-	binary.LittleEndian.PutUint64(marshaledID[0:8], id.Height)
-	copy(marshaledID[8:40], id.Commitment) // Commitment is 32 bytes
-	binary.LittleEndian.PutUint32(marshaledID[40:44], id.ShareOffset)
-	binary.LittleEndian.PutUint32(marshaledID[44:48], id.ShareSize)
+	binary.LittleEndian.PutUint64(id[0:8], c.Height)
+	copy(id[8:40], c.Commitment) // Commitment is 32 bytes
+	binary.LittleEndian.PutUint32(id[40:44], c.ShareOffset)
+	binary.LittleEndian.PutUint32(id[44:48], c.ShareSize)
 
-	return marshaledID, nil
+	return id, nil
 }
 
 // UnmarshalBinary deserializes a byte slice into a CelestiaBlobID struct.
-func (id *CelestiaBlobID) UnmarshalBinary(data []byte) error {
+func (c *CelestiaBlobID) UnmarshalBinary(data []byte) error {
 	// Expected length: 8 bytes for Height + 32 bytes for Commitment + 4 bytes for ShareOffset + 4 bytes for ShareSize
 	expectedLen := 8 + 32 + 4 + 4
 	if len(data) < expectedLen {
@@ -49,17 +49,17 @@ func (id *CelestiaBlobID) UnmarshalBinary(data []byte) error {
 		if len(data) < expectedLen {
 			return fmt.Errorf("invalid ID length: expected at least %d bytes, got %d", expectedLen, len(data))
 		}
-		id.Height = binary.LittleEndian.Uint64(data[0:8])
-		id.Commitment = make([]byte, 32)
-		copy(id.Commitment, data[8:40]) // Commitment is 32 bytes
+		c.Height = binary.LittleEndian.Uint64(data[0:8])
+		c.Commitment = make([]byte, 32)
+		copy(c.Commitment, data[8:40]) // Commitment is 32 bytes
 		return nil
 	}
 
-	id.Height = binary.LittleEndian.Uint64(data[0:8])
-	id.Commitment = make([]byte, 32)
-	copy(id.Commitment, data[8:40]) // Commitment is 32 bytes
-	id.ShareOffset = binary.LittleEndian.Uint32(data[40:44])
-	id.ShareSize = binary.LittleEndian.Uint32(data[44:48])
+	c.Height = binary.LittleEndian.Uint64(data[0:8])
+	c.Commitment = make([]byte, 32)
+	copy(c.Commitment, data[8:40]) // Commitment is 32 bytes
+	c.ShareOffset = binary.LittleEndian.Uint32(data[40:44])
+	c.ShareSize = binary.LittleEndian.Uint32(data[44:48])
 
 	return nil
 }
@@ -186,13 +186,13 @@ func (d *CelestiaStore) Put(ctx context.Context, data []byte) ([]byte, error) {
 		ShareSize:   uint32(size),
 	}
 
-	marshaledID, err := blobID.MarshalBinary()
+	id, err := blobID.MarshalBinary()
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal blob ID: %w", err)
 	}
 
-	d.Log.Info("celestia: blob successfully submitted", "id", hex.EncodeToString(marshaledID))
-	commitment := altda.NewGenericCommitment(append([]byte{VersionByte}, marshaledID...))
+	d.Log.Info("celestia: blob successfully submitted", "id", hex.EncodeToString(id))
+	commitment := altda.NewGenericCommitment(append([]byte{VersionByte}, id...))
 	return commitment.Encode(), nil
 }
 

--- a/celestia_storage.go
+++ b/celestia_storage.go
@@ -44,7 +44,15 @@ func (id *CelestiaBlobID) UnmarshalBinary(data []byte) error {
 	// Expected length: 8 bytes for Height + 32 bytes for Commitment + 4 bytes for ShareOffset + 4 bytes for ShareSize
 	expectedLen := 8 + 32 + 4 + 4
 	if len(data) < expectedLen {
-		return fmt.Errorf("invalid ID length: expected at least %d bytes, got %d", expectedLen, len(data))
+		// Expected length: 8 bytes for Height + 32 bytes for Commitment
+		expectedLen = 8 + 32
+		if len(data) < expectedLen {
+			return fmt.Errorf("invalid ID length: expected at least %d bytes, got %d", expectedLen, len(data))
+		}
+		id.Height = binary.LittleEndian.Uint64(data[0:8])
+		id.Commitment = make([]byte, 32)
+		copy(id.Commitment, data[8:40]) // Commitment is 32 bytes
+		return nil
 	}
 
 	id.Height = binary.LittleEndian.Uint64(data[0:8])

--- a/celestia_storage_test.go
+++ b/celestia_storage_test.go
@@ -56,7 +56,7 @@ func TestCelestiaBlobIDMarshalUnmarshal(t *testing.T) {
 	assert.True(t, bytes.Equal(id2.Commitment, unmarshaled2.Commitment))
 
 	// Test case 3: Invalid length for UnmarshalBinary
-	invalidData := make([]byte, 40) // Too short
+	invalidData := make([]byte, 32) // Too short
 	var invalidID CelestiaBlobID
 	err = invalidID.UnmarshalBinary(invalidData)
 	require.Error(t, err)

--- a/celestia_storage_test.go
+++ b/celestia_storage_test.go
@@ -55,7 +55,24 @@ func TestCelestiaBlobIDMarshalUnmarshal(t *testing.T) {
 	assert.Equal(t, id2.ShareSize, unmarshaled2.ShareSize)
 	assert.True(t, bytes.Equal(id2.Commitment, unmarshaled2.Commitment))
 
-	// Test case 3: Invalid length for UnmarshalBinary
+	// Test case 3: Legacy id format (height, commitment) 8 + 32 = 40 bytes
+	commitment3 := make([]byte, 32)
+	rnd.Read(commitment1)
+	id3 := CelestiaBlobID{
+		Height:      rnd.Uint64(),
+		Commitment:  commitment3,
+		ShareOffset: rnd.Uint32(),
+		ShareSize:   rnd.Uint32(),
+	}
+	marshaled3, err := id3.MarshalBinary()
+	require.NoError(t, err)
+	var unmarshaled3 CelestiaBlobID
+	err = unmarshaled3.UnmarshalBinary(marshaled3[:40])
+	require.NoError(t, err)
+	require.Equal(t, unmarshaled3.ShareOffset, uint32(0))
+	require.Equal(t, unmarshaled3.ShareSize, uint32(0))
+
+	// Test case 4: Invalid length for UnmarshalBinary
 	invalidData := make([]byte, 32) // Too short
 	var invalidID CelestiaBlobID
 	err = invalidID.UnmarshalBinary(invalidData)

--- a/celestia_storage_test.go
+++ b/celestia_storage_test.go
@@ -1,0 +1,64 @@
+package celestia
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCelestiaBlobIDMarshalUnmarshal(t *testing.T) {
+	rnd := rand.New(rand.NewSource(123))
+
+	// Test case 1: Full data
+	commitment1 := make([]byte, 32)
+	rnd.Read(commitment1)
+	id1 := CelestiaBlobID{
+		Height:      rnd.Uint64(),
+		Commitment:  commitment1,
+		ShareOffset: rnd.Uint32(),
+		ShareSize:   rnd.Uint32(),
+	}
+
+	marshaled1, err := id1.MarshalBinary()
+	require.NoError(t, err)
+	require.Len(t, marshaled1, 48)
+
+	var unmarshaled1 CelestiaBlobID
+	err = unmarshaled1.UnmarshalBinary(marshaled1)
+	require.NoError(t, err)
+	assert.Equal(t, id1.Height, unmarshaled1.Height)
+	assert.Equal(t, id1.ShareOffset, unmarshaled1.ShareOffset)
+	assert.Equal(t, id1.ShareSize, unmarshaled1.ShareSize)
+	assert.True(t, bytes.Equal(id1.Commitment, unmarshaled1.Commitment))
+
+	// Test case 2: Zero values
+	commitment2 := make([]byte, 32)
+	id2 := CelestiaBlobID{
+		Height:      0,
+		Commitment:  commitment2,
+		ShareOffset: 0,
+		ShareSize:   0,
+	}
+
+	marshaled2, err := id2.MarshalBinary()
+	require.NoError(t, err)
+	require.Len(t, marshaled2, 48)
+
+	var unmarshaled2 CelestiaBlobID
+	err = unmarshaled2.UnmarshalBinary(marshaled2)
+	require.NoError(t, err)
+	assert.Equal(t, id2.Height, unmarshaled2.Height)
+	assert.Equal(t, id2.ShareOffset, unmarshaled2.ShareOffset)
+	assert.Equal(t, id2.ShareSize, unmarshaled2.ShareSize)
+	assert.True(t, bytes.Equal(id2.Commitment, unmarshaled2.Commitment))
+
+	// Test case 3: Invalid length for UnmarshalBinary
+	invalidData := make([]byte, 40) // Too short
+	var invalidID CelestiaBlobID
+	err = invalidID.UnmarshalBinary(invalidData)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid ID length")
+}

--- a/cmd/daserver/flags.go
+++ b/cmd/daserver/flags.go
@@ -31,6 +31,7 @@ const (
 	CelestiaCoreGRPCTLSEnabledFlagName = "celestia.core.grpc.tls-enabled"
 	CelestiaCoreGRPCAuthTokenFlagName  = "celestia.core.grpc.auth-token"
 	CelestiaP2PNetworkFlagName         = "celestia.p2p-network"
+	CelestiaCompactBlobIDFlagName      = "celestia.compact-blobid"
 	//s3
 	S3CredentialTypeFlagName  = "s3.credential-type" // #nosec G101
 	S3BucketFlagName          = "s3.bucket"          // #nosec G101
@@ -161,6 +162,12 @@ var (
 			return nil
 		},
 	}
+	CelestiaBlobIDCompactFlag = &cli.BoolFlag{
+		Name:    CelestiaCompactBlobIDFlagName,
+		Usage:   "enable compact celestia blob IDs. false indicates share offset and size will be included in the blob ID",
+		Value:   true,
+		EnvVars: prefixEnvVars("CELESTIA_BLOBID_COMPACT"),
+	}
 	S3CredentialTypeFlag = &cli.StringFlag{
 		Name:    S3CredentialTypeFlagName,
 		Usage:   "The way to authenticate to S3, options are [iam, static]",
@@ -239,6 +246,7 @@ var optionalFlags = []cli.Flag{
 	S3TimeoutFlag,
 	FallbackFlag,
 	CacheFlag,
+	CelestiaBlobIDCompactFlag,
 }
 
 func init() {
@@ -250,35 +258,37 @@ func init() {
 var Flags []cli.Flag
 
 type CLIConfig struct {
-	UseGenericComm     bool
-	CelestiaEndpoint   string
-	CelestiaTLSEnabled bool
-	CelestiaAuthToken  string
-	CelestiaNamespace  string
-	DefaultKeyName     string
-	KeyringPath        string
-	CoreGRPCAddr       string
-	CoreGRPCTLSEnabled bool
-	CoreGRPCAuthToken  string
-	P2PNetwork         string
-	S3Config           s3.S3Config
-	Fallback           bool
-	Cache              bool
+	UseGenericComm        bool
+	CelestiaEndpoint      string
+	CelestiaTLSEnabled    bool
+	CelestiaAuthToken     string
+	CelestiaNamespace     string
+	DefaultKeyName        string
+	KeyringPath           string
+	CoreGRPCAddr          string
+	CoreGRPCTLSEnabled    bool
+	CoreGRPCAuthToken     string
+	P2PNetwork            string
+	CelestiaCompactBlobID bool
+	S3Config              s3.S3Config
+	Fallback              bool
+	Cache                 bool
 }
 
 func ReadCLIConfig(ctx *cli.Context) CLIConfig {
 	return CLIConfig{
-		UseGenericComm:     ctx.Bool(GenericCommFlagName),
-		CelestiaEndpoint:   ctx.String(CelestiaAddrFlagName),
-		CelestiaTLSEnabled: ctx.Bool(CelestiaTLSEnabledFlagName),
-		CelestiaAuthToken:  ctx.String(CelestiaAuthTokenFlagName),
-		CelestiaNamespace:  ctx.String(CelestiaNamespaceFlagName),
-		DefaultKeyName:     ctx.String(CelestiaDefaultKeyNameFlagName),
-		KeyringPath:        ctx.String(CelestiaKeyringPathFlagName),
-		CoreGRPCAddr:       ctx.String(CelestiaCoreGRPCAddrFlagName),
-		CoreGRPCTLSEnabled: ctx.Bool(CelestiaCoreGRPCTLSEnabledFlagName),
-		CoreGRPCAuthToken:  ctx.String(CelestiaCoreGRPCAuthTokenFlagName),
-		P2PNetwork:         ctx.String(CelestiaP2PNetworkFlagName),
+		UseGenericComm:        ctx.Bool(GenericCommFlagName),
+		CelestiaEndpoint:      ctx.String(CelestiaAddrFlagName),
+		CelestiaTLSEnabled:    ctx.Bool(CelestiaTLSEnabledFlagName),
+		CelestiaAuthToken:     ctx.String(CelestiaAuthTokenFlagName),
+		CelestiaNamespace:     ctx.String(CelestiaNamespaceFlagName),
+		DefaultKeyName:        ctx.String(CelestiaDefaultKeyNameFlagName),
+		KeyringPath:           ctx.String(CelestiaKeyringPathFlagName),
+		CoreGRPCAddr:          ctx.String(CelestiaCoreGRPCAddrFlagName),
+		CoreGRPCTLSEnabled:    ctx.Bool(CelestiaCoreGRPCTLSEnabledFlagName),
+		CoreGRPCAuthToken:     ctx.String(CelestiaCoreGRPCAuthTokenFlagName),
+		P2PNetwork:            ctx.String(CelestiaP2PNetworkFlagName),
+		CelestiaCompactBlobID: ctx.Bool(CelestiaCompactBlobIDFlagName),
 		S3Config: s3.S3Config{
 			S3CredentialType: toS3CredentialType(ctx.String(S3CredentialTypeFlagName)),
 			Bucket:           ctx.String(S3BucketFlagName),
@@ -318,6 +328,7 @@ func (c CLIConfig) CelestiaConfig() celestia.CelestiaConfig {
 		CoreGRPCTLSEnabled: c.CoreGRPCTLSEnabled,
 		CoreGRPCAuthToken:  c.CoreGRPCAuthToken,
 		P2PNetwork:         c.P2PNetwork,
+		CompactBlobID:      c.CelestiaCompactBlobID,
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/ethereum-optimism/optimism v1.13.5
 	github.com/ethereum/go-ethereum v1.15.11
 	github.com/minio/minio-go/v7 v7.0.85
+	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli/v2 v2.27.6
 )
 
@@ -321,7 +322,6 @@ require (
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/spf13/viper v1.20.0 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.5.0 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/supranational/blst v0.3.14 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect


### PR DESCRIPTION
## Overview

This PR adds the start index and length of the blob to the commitment. It is required for proving blob existence.