### PR TITLE
fix(server): split err, nil blob handling

### DIFF
--- a/celestia_storage.go
+++ b/celestia_storage.go
@@ -115,8 +115,11 @@ func (d *CelestiaStore) Get(ctx context.Context, key []byte) ([]byte, error) {
 	height, commitment := SplitID(key[2:])
 	blob, err := d.Client.Blob.Get(ctx, height, d.Namespace, commitment)
 	cancel()
-	if err != nil || blob == nil {
+	if err != nil {
 		return nil, fmt.Errorf("celestia: failed to resolve frame: %w", err)
+	}
+	if blob == nil {
+		return nil, fmt.Errorf("celestia: failed to resolve frame: nil blob")
 	}
 	return blob.Data(), nil
 }


### PR DESCRIPTION
## Overview

This PR separates the handling of error case and case where blob is nil. This fixes a bug where errors were being silenced.