### PR TITLE
fix key path and ignore s3 if not set

### DIFF
--- a/celestia_storage.go
+++ b/celestia_storage.go
@@ -103,6 +103,7 @@ func NewCelestiaStore(cfg CelestiaConfig) *CelestiaStore {
 	if keyname == "" {
 		keyname = "my_celes_key"
 	}
+	log.Info("creating keyring", "keyname", keyname, "keyringpath", cfg.KeyringPath)
 	kr, err := client.KeyringWithNewKey(client.KeyringConfig{
 		KeyName:     keyname,
 		BackendName: keyring.BackendTest,

--- a/cmd/daserver/entrypoint.go
+++ b/cmd/daserver/entrypoint.go
@@ -39,10 +39,15 @@ func StartDAServer(cliCtx *cli.Context) error {
 	case cfg.CelestiaEnabled():
 		l.Info("Using celestia storage", "url", cfg.CelestiaConfig().URL)
 		store := celestia.NewCelestiaStore(cfg.CelestiaConfig())
-		l.Info("Using s3 storage", "config", cfg.S3Config)
-		s3Store, err := s3.NewS3(cfg.S3Config)
-		if err != nil {
-			return err
+		var s3Store *s3.S3Store
+		if cfg.S3Enabled() {
+			l.Info("Using s3 storage", "config", cfg.S3Config)
+			var err error
+			s3Store, err = s3.NewS3(cfg.S3Config)
+			if err != nil {
+				l.Error("failed to create s3 store", "err", err)
+				return err
+			}
 		}
 		server = celestia.NewCelestiaServer(cliCtx.String(ListenAddrFlagName), cliCtx.Int(PortFlagName), store, s3Store, cfg.FallbackEnabled(), cfg.CacheEnabled(), l)
 	}

--- a/cmd/daserver/flags.go
+++ b/cmd/daserver/flags.go
@@ -54,7 +54,7 @@ func prefixEnvVars(name string) []string {
 var DefaultKeyringPath = func(tp string, network string) (string, error) {
 	home := os.Getenv("CELESTIA_HOME")
 	if home != "" {
-		return home, nil
+		return fmt.Sprintf("%s/keys", home), nil
 	}
 
 	home, err := os.UserHomeDir()
@@ -147,6 +147,9 @@ var (
 		Value:   "mocha-4",
 		EnvVars: prefixEnvVars("CELESTIA_P2P_NETWORK"),
 		Action: func(c *cli.Context, network string) error {
+			if c.IsSet(CelestiaKeyringPathFlagName) {
+				return nil
+			}
 			keyringPath, err := DefaultKeyringPath("light", network)
 			if err != nil {
 				return err
@@ -324,6 +327,10 @@ func (c CLIConfig) CelestiaConfig() celestia.CelestiaConfig {
 
 func (c CLIConfig) CelestiaEnabled() bool {
 	return !(c.CelestiaEndpoint == "" && c.CelestiaAuthToken == "" && c.CelestiaNamespace == "")
+}
+
+func (c CLIConfig) S3Enabled() bool {
+	return !(c.S3Config.Endpoint == "" && c.S3Config.AccessKeyID == "" && c.S3Config.AccessKeySecret == "")
 }
 
 func (c CLIConfig) CacheEnabled() bool {


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This PR fixes the following bugs

- https://github.com/celestiaorg/op-alt-da/issues/13
- `--celestia.keyring.path` was getting overriden if `p2p-network` was set
- `DefaultKeyringPath` was returning wrong value for the keys path if `CELESTIA_HOME` was set
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
