### PR TITLE
feat(server): add prometheus metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,14 @@ celestia da-server accepts the following flags for celestia storage using
    --celestia.tx-client.core-grpc.auth-token value  celestia tx client core grpc auth token [$OP_ALTDA_CELESTIA_TX_CLIENT_CORE_GRPC_AUTH_TOKEN]
    --celestia.tx-client.p2p-network value           celestia tx client p2p network (default: "mocha-4") [$OP_ALTDA_CELESTIA_TX_CLIENT_P2P_NETWORK]
    --celestia.compact-blobid                        enable compact celestia blob IDs. false indicates share offset and size will be included in the blob ID (default: true) [$OP_ALTDA_CELESTIA_BLOBID_COMPACT]
-   --log.level value                                The lowest log level that will be output (default: INFO) [$OP_ALTDA_LOG_LEVEL]
-   --log.format value                               Format the log output. Supported formats: 'text', 'terminal', 'logfmt', 'json', 'json-pretty', (default: text) [$OP_ALTDA_LOG_FORMAT]
-   --log.color                                      Color the log output if in terminal mode (default: false) [$OP_ALTDA_LOG_COLOR]
-   --log.pid                                        Show pid in the log (default: false) [$OP_ALTDA_LOG_PID]
-   --help, -h                                       show help
-   --version, -v                                    print the version
+    --log.level value                                The lowest log level that will be output (default: INFO) [$OP_ALTDA_LOG_LEVEL]
+    --log.format value                               Format the log output. Supported formats: 'text', 'terminal', 'logfmt', 'json', 'json-pretty', (default: text) [$OP_ALTDA_LOG_FORMAT]
+    --log.color                                      Color the log output if in terminal mode (default: false) [$OP_ALTDA_LOG_COLOR]
+    --log.pid                                        Show pid in the log (default: false) [$OP_ALTDA_LOG_PID]
+    --metrics.enabled                                Enable Prometheus metrics (default: false) [$OP_ALTDA_METRICS_ENABLED]
+    --metrics.port value                             Port for Prometheus metrics server (default: 6060) [$OP_ALTDA_METRICS_PORT]
+    --help, -h                                       show help
+    --version, -v                                    print the version
 ````
 
 ## RPC Connection

--- a/cmd/daserver/entrypoint.go
+++ b/cmd/daserver/entrypoint.go
@@ -48,7 +48,7 @@ func StartDAServer(cliCtx *cli.Context) error {
 				return err
 			}
 		}
-		server = celestia.NewCelestiaServer(cliCtx.String(ListenAddrFlagName), cliCtx.Int(PortFlagName), store, s3Store, cfg.FallbackEnabled(), cfg.CacheEnabled(), l)
+		server = celestia.NewCelestiaServer(cliCtx.String(ListenAddrFlagName), cliCtx.Int(PortFlagName), store, s3Store, cfg.FallbackEnabled(), cfg.CacheEnabled(), cfg.MetricsEnabled, cfg.MetricsPort, l)
 	}
 
 	if err := server.Start(); err != nil {

--- a/cmd/daserver/flags.go
+++ b/cmd/daserver/flags.go
@@ -43,6 +43,10 @@ const (
 	S3TimeoutFlagName         = "s3.timeout"
 	FallbackFlagName          = "routing.fallback"
 	CacheFlagName             = "routing.cache"
+
+	// metrics
+	MetricsEnabledFlagName = "metrics.enabled"
+	MetricsPortFlagName    = "metrics.port"
 )
 
 const EnvVarPrefix = "OP_ALTDA"
@@ -181,6 +185,18 @@ var (
 		Value:   false,
 		EnvVars: prefixEnvVars("CACHE"),
 	}
+	MetricsEnabledFlag = &cli.BoolFlag{
+		Name:    MetricsEnabledFlagName,
+		Usage:   "Enable Prometheus metrics",
+		Value:   false,
+		EnvVars: prefixEnvVars("METRICS_ENABLED"),
+	}
+	MetricsPortFlag = &cli.IntFlag{
+		Name:    MetricsPortFlagName,
+		Usage:   "Port for Prometheus metrics server",
+		Value:   6060,
+		EnvVars: prefixEnvVars("METRICS_PORT"),
+	}
 )
 var requiredFlags = []cli.Flag{
 	CelestiaNamespaceFlag,
@@ -208,6 +224,8 @@ var optionalFlags = []cli.Flag{
 	S3TimeoutFlag,
 	FallbackFlag,
 	CacheFlag,
+	MetricsEnabledFlag,
+	MetricsPortFlag,
 }
 
 // Flags contains the list of configuration options available to the binary.
@@ -228,6 +246,8 @@ type CLIConfig struct {
 	S3Config              s3.S3Config
 	Fallback              bool
 	Cache                 bool
+	MetricsEnabled        bool
+	MetricsPort           int
 }
 
 func ReadCLIConfig(ctx *cli.Context) CLIConfig {
@@ -254,8 +274,10 @@ func ReadCLIConfig(ctx *cli.Context) CLIConfig {
 			AccessKeySecret:  ctx.String(S3AccessKeySecretFlagName),
 			Timeout:          ctx.Duration(S3TimeoutFlagName),
 		},
-		Fallback: ctx.Bool(FallbackFlagName),
-		Cache:    ctx.Bool(CacheFlagName),
+		Fallback:       ctx.Bool(FallbackFlagName),
+		Cache:          ctx.Bool(CacheFlagName),
+		MetricsEnabled: ctx.Bool(MetricsEnabledFlagName),
+		MetricsPort:    ctx.Int(MetricsPortFlagName),
 	}
 }
 


### PR DESCRIPTION
## Overview

This PR adds prometheus metrics to the celestia server. Metrics added are:

- `op_altda_request_duration_seconds`
- `op_altda_blob_size_bytes`
- `op_altda_inclusion_height`