### PR TITLE
update celestia-node

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/celestiaorg/op-alt-da
 go 1.24.6
 
 require (
-	github.com/celestiaorg/celestia-node v0.28.2-mocha
+	github.com/celestiaorg/celestia-node v0.28.2
 	github.com/celestiaorg/go-square/v3 v3.0.2
 	github.com/cosmos/cosmos-sdk v0.50.13
 	github.com/ethereum-optimism/optimism v1.13.5

--- a/go.sum
+++ b/go.sum
@@ -795,8 +795,8 @@ github.com/celestiaorg/celestia-app/v6 v6.2.0-mocha h1:TgFkGobm7HzVVTgiop6IdrSOK
 github.com/celestiaorg/celestia-app/v6 v6.2.0-mocha/go.mod h1:xfluvwbj2m3zPM767BIXVHK7J1EiunKghEz4c1JHwzo=
 github.com/celestiaorg/celestia-core v0.39.10 h1:49adyR+oL9BRbaV9iDPWGSsIlU2OgS6R7mRJ9p16hI8=
 github.com/celestiaorg/celestia-core v0.39.10/go.mod h1:QFllLrTDEE112fdKWH9+367OWDNskZpUtyiUsj4oezo=
-github.com/celestiaorg/celestia-node v0.28.2-mocha h1:U6AUThiSsyoXEO72Ftf0s+B7m3lwnKcx6J95sHo/C00=
-github.com/celestiaorg/celestia-node v0.28.2-mocha/go.mod h1:rwuv4NhcV4lPUs0PBYPV1nlDaVmu20Oehy4PdanC4PQ=
+github.com/celestiaorg/celestia-node v0.28.2 h1:zM+qIDn0Byglj+n6ZeiEPXZuJHbHkjZ7E0cVOGImTRE=
+github.com/celestiaorg/celestia-node v0.28.2/go.mod h1:rwuv4NhcV4lPUs0PBYPV1nlDaVmu20Oehy4PdanC4PQ=
 github.com/celestiaorg/cosmos-sdk v0.51.4 h1:4yQQ+3NqvfcrO3Im1dbzSPF7Ujvw8P0IIisRWVXjWLg=
 github.com/celestiaorg/cosmos-sdk v0.51.4/go.mod h1:YRNOXtC4vo5FG1SSoj57yEUiidU8Pn3ofjqYlFdu8qg=
 github.com/celestiaorg/cosmos-sdk/api v0.7.6 h1:81in9Zk+noz0ko+hZFSSK8L1aawFN8/CmdcQAUhbiUU=


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

updates celestia-node to v0.28.2, marking the 0.9.0 ready for the Celestia V6 upgrade  
