### PR TITLE
Add ca-certificates package to the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN make da-server
 
 FROM alpine:3.18
 
+RUN apk add --no-cache ca-certificates
+
 COPY --from=builder /op-alt-da/bin/da-server /usr/local/bin/da-server
 
 EXPOSE 3100


### PR DESCRIPTION
## Overview
Without the ca-certificates package in the image, the alt-da server can't connect to a Celestia RPC which is using HTTPS.
