### PR TITLE
Update DefaultKeyName to use keyname variable

### DIFF
--- a/celestia_storage.go
+++ b/celestia_storage.go
@@ -215,7 +215,7 @@ func initTxClient(ctx context.Context, cfg RPCClientConfig) (blobAPI.Module, err
 			EnableDATLS:  cfg.TLSEnabled,
 		},
 		SubmitConfig: txClient.SubmitConfig{
-			DefaultKeyName:   cfg.TxClientConfig.DefaultKeyName,
+			DefaultKeyName:   keyname,
 			Network:          p2p.Network(cfg.TxClientConfig.P2PNetwork),
 			TxWorkerAccounts: cfg.TxClientConfig.TxWorkerAccounts,
 			CoreGRPCConfig: txClient.CoreGRPCConfig{


### PR DESCRIPTION
Since keyname is updated on line 196, I think to keep things consistent one has to use the updated keyname.
```
	if keyname == "" {
		keyname = "my_celes_key"
	}
```
