### PR TITLE
fix: ci disable release cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
       - uses: actions/setup-go@v5.0.0
         with:
           go-version-file: 'go.mod'
-          cache: true
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io


### PR DESCRIPTION
## Overview

This PR disables cache in release workflow, was probably causing disk space error during new releases.