### PR TITLE
update base images, add wget for healthchecks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine3.22 AS builder
+FROM golang:1.26-alpine3.23 AS builder
 
 WORKDIR /
 COPY . op-alt-da
@@ -6,9 +6,10 @@ RUN apk add --no-cache make ca-certificates && update-ca-certificates
 WORKDIR /op-alt-da
 RUN make da-server 
 
-FROM alpine:3.18
+FROM alpine:3.23
 
-RUN apk add --no-cache ca-certificates && update-ca-certificates
+# wget for internal healthcheck
+RUN apk add --no-cache ca-certificates wget && update-ca-certificates
 
 COPY --from=builder /op-alt-da/bin/da-server /usr/local/bin/da-server
 


### PR DESCRIPTION
a nice-to-have utility in the container to allow for healthchecks like in this example docker compose service:

```yaml
services:
  op-alt-da:
    image: ghcr.io/celestiaorg/op-alt-da:<some real tag>
    restart: unless-stopped
    networks:
      - shared
    ports:
      - "${OP_ALT_DA_PORT}:${OP_ALT_DA_PORT}"
    expose:
      - "${OP_ALT_DA_METRICS_PORT}"
    volumes:
      - ${CELESTIA_TX_KEYRING_PATH}:${CELESTIA_TX_KEYRING_PATH}:ro
    command:
      - --addr=0.0.0.0
      - --port=${OP_ALT_DA_PORT}
      - --metrics.enabled
      - --metrics.port=${OP_ALT_DA_METRICS_PORT}
      - --log.level=${LOG_LEVEL}
      - --celestia.namespace=${CELESTIA_NAMESPACE}
      - --celestia.server=http://celestia-bridge:${CELESTIA_NODE_RPC_PORT}
      - --celestia.tls-enabled=false
      - --celestia.tx-client.core-grpc.addr=celestia-app:${CELESTIA_CORE_GRPC_PORT}
      - --celestia.tx-client.core-grpc.tls-enabled=false
      - --celestia.tx-client.keyring-path=${CELESTIA_TX_KEYRING_PATH}
      - --celestia.tx-client.key-name=${CELESTIA_TX_KEY_NAME}
      - --celestia.tx-client.p2p-network=${CELESTIA_NETWORK}

    healthcheck:
      test: ["CMD-SHELL", "wget -qO- http://localhost:${OP_ALT_DA_PORT}/health > /dev/null 2>&1 || exit 1"]
      interval: 5s
      timeout: 3s
      retries: 20
```